### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index] 
 
   def index
-    @items = Item.includes(:user)
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index] 
+  before_action :move_to_index, except: [:index]
 
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
@@ -22,7 +22,8 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :image, :description, :category_id, :condition_id, :delivery_charge_id,:delivery_area_id, :delivery_day_id, :item_price).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :image, :description, :category_id, :condition_id, :delivery_charge_id, :delivery_area_id,
+                                 :delivery_day_id, :item_price).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index] 
 
   def index
+    @items = Item.includes(:user)
   end
 
   def new
@@ -21,8 +22,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :image, :description, :category_id, :condition_id, :delivery_charge_id,
-                                 :delivery_area_id, :delivery_day_id, :item_price).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :image, :description, :category_id, :condition_id, :delivery_charge_id,:delivery_area_id, :delivery_day_id, :item_price).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,40 +127,40 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%#= image_tag "item.image", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+      <% if @items.length > 0 %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <% link_to root_path %>
+          <%# //商品詳細ページへのパスに変更 %>
+          <div class='item-img-content'>
+            <%= image_tag item.image.variant(resize: '231.31x231.31'), class: "item-img" if item.image.attached? %>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <%# unless item.order = nil %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# end %>
+            <%# //商品が売れていればsold outを表示しましょう %>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.item_price %>円<br><%= item.deliveryCharge.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+        </li>
+      <% end %>
+    
+      <% else %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <% link_to root_path %>
+        <%# //商品詳細ページへのパスに変更 %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -174,14 +174,13 @@
             </div>
           </div>
         </div>
-        <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>
 </div>
+
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Item, type: :model do
       it '価格に半角数字以外が含まれている場合は出品できない' do
         @item.item_price = 'テスト'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item price is not a number")
+        expect(@item.errors.full_messages).to include('Item price is not a number')
       end
 
       it '価格が300円以上でないと新規出品できない' do


### PR DESCRIPTION
#what
商品一覧ページの編集
#why
商品一覧表示機能の実装のため

※「売却済みの商品は、画像上に『sold out』の文字が表示されること」は、商品購入機能実装後に実装します。

よろしくお願いします！


・商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/8475018bba7fa4bf73798ff950f71827

・商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/97aae8ecf25b2f68cdbb97037a5d32c8
